### PR TITLE
feat: pass on HTTP status code as error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ The response will contain the status code, the headers and the body of the respo
 }
 ```
 
+### Error codes
+
+The Connector will fail on any non-2XX HTTP status code in the response. This error status code will be passed on as error code, e.g. "404".
+
 ## Test locally
 
 Run unit tests

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-parent</artifactId>
-        <version>0.2.2</version>
+        <version>0.3.0-alpha2</version>
         <relativePath/>
     </parent>
 
@@ -153,7 +153,7 @@
                 <dependency>
                     <groupId>io.camunda.connector</groupId>
                     <artifactId>connector-runtime-cloud</artifactId>
-                    <version>0.2.0</version>
+                    <version>0.3.0-alpha2</version>
                 </dependency>
             </dependencies>
             <build>

--- a/src/test/java/io/camunda/connector/http/HttpJsonFunctionTest.java
+++ b/src/test/java/io/camunda/connector/http/HttpJsonFunctionTest.java
@@ -18,9 +18,11 @@ package io.camunda.connector.http;
 
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,24 +32,24 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.json.gson.GsonFactory;
-import com.google.gson.JsonObject;
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.http.model.HttpJsonRequest;
 import io.camunda.connector.http.model.HttpJsonResult;
+import io.camunda.connector.impl.ConnectorInputException;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -74,8 +76,8 @@ public class HttpJsonFunctionTest extends BaseTest {
   @MethodSource("successCases")
   public void shouldReturnResult_WhenExecuted(final String input) throws IOException {
     // given - minimal required entity
-    final OutboundConnectorContext context = Mockito.mock(OutboundConnectorContext.class);
-    when(context.getVariables()).thenReturn(input);
+    final var context =
+        OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
 
     when(requestFactory.buildRequest(
             anyString(), any(GenericUrl.class), nullable(HttpContent.class)))
@@ -85,27 +87,28 @@ public class HttpJsonFunctionTest extends BaseTest {
     when(httpRequest.execute()).thenReturn(httpResponse);
 
     // when
-    Object functionCallResponseAsObject = functionUnderTest.execute(context);
+    var functionCallResponseAsObject = functionUnderTest.execute(context);
 
     // then
     verify(httpRequest).execute();
     assertThat(functionCallResponseAsObject).isInstanceOf(HttpJsonResult.class);
-    HttpJsonResult functionCallResponse = (HttpJsonResult) functionCallResponseAsObject;
-    assertThat(functionCallResponse.getHeaders()).containsValue(APPLICATION_JSON.getMimeType());
+    assertThat(((HttpJsonResult) functionCallResponseAsObject).getHeaders())
+        .containsValue(APPLICATION_JSON.getMimeType());
   }
 
   @ParameterizedTest(name = "Executing test case: {0}")
   @MethodSource("failCases")
   public void shouldReturnFallbackResult_WhenMalformedRequest(final String input) {
-    final OutboundConnectorContext ctx =
-        OutboundConnectorContextBuilder.create().variables(input).build();
+    final var context =
+        OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
 
     // when
-    Throwable exceptionThrown =
-        Assertions.assertThrows(RuntimeException.class, () -> functionUnderTest.execute(ctx));
+    var exceptionThrown = catchException(() -> functionUnderTest.execute(context));
 
     // then
-    assertThat(exceptionThrown).isInstanceOf(RuntimeException.class);
+    assertThat(exceptionThrown)
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageContaining("ValidationException");
   }
 
   @Test
@@ -116,8 +119,7 @@ public class HttpJsonFunctionTest extends BaseTest {
     final var response =
         "{ \"createdAt\": \"2022-10-10T05:03:14.723Z\", \"name\": \"Marvin Cremin\", \"unknown\": null, \"id\": \"1\" }";
 
-    final OutboundConnectorContext context =
-        OutboundConnectorContextBuilder.create().variables(request).build();
+    final var context = OutboundConnectorContextBuilder.create().variables(request).build();
     when(requestFactory.buildRequest(
             anyString(), any(GenericUrl.class), nullable(HttpContent.class)))
         .thenReturn(httpRequest);
@@ -127,10 +129,11 @@ public class HttpJsonFunctionTest extends BaseTest {
         .thenReturn(new ByteArrayInputStream(response.getBytes(StandardCharsets.UTF_8)));
     when(httpRequest.execute()).thenReturn(httpResponse);
     // when connector execute
-    Object functionCallResponseAsObject = functionUnderTest.execute(context);
-    // then null field 'unknown' exist in response body and equal null
-    HttpJsonResult result = (HttpJsonResult) functionCallResponseAsObject;
-    JsonObject asJsonObject = gson.toJsonTree(result.getBody()).getAsJsonObject();
+    var functionCallResponseAsObject = functionUnderTest.execute(context);
+    // then null field 'unknown' exists in response body and has a null value
+    var asJsonObject =
+        gson.toJsonTree(((HttpJsonResult) functionCallResponseAsObject).getBody())
+            .getAsJsonObject();
     assertThat(asJsonObject.has("unknown")).isTrue();
     assertThat(asJsonObject.get("unknown").isJsonNull()).isTrue();
   }
@@ -139,8 +142,12 @@ public class HttpJsonFunctionTest extends BaseTest {
   @MethodSource("successCases")
   public void execute_shouldSetConnectTime(final String input) throws IOException {
     // given - minimal required entity
-    final OutboundConnectorContext context = Mockito.mock(OutboundConnectorContext.class);
-    when(context.getVariables()).thenReturn(input);
+    final var context =
+        OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
+    final var expectedTimeInMilliseconds =
+        Integer.parseInt(
+                gson.fromJson(input, HttpJsonRequest.class).getConnectionTimeoutInSeconds())
+            * 1000;
 
     when(requestFactory.buildRequest(
             anyString(), any(GenericUrl.class), nullable(HttpContent.class)))
@@ -151,10 +158,32 @@ public class HttpJsonFunctionTest extends BaseTest {
     // when
     functionUnderTest.execute(context);
     // then
-    String connectTimeout =
-        gson.fromJson(input, HttpJsonRequest.class).getConnectionTimeoutInSeconds();
-    int expectedTimeInMilliseconds = Integer.parseInt(connectTimeout) * 1000;
     verify(httpRequest).setConnectTimeout(expectedTimeInMilliseconds);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {400, 404, 500})
+  public void execute_shouldPassOnHttpErrorAsErrorCode(final int input) throws IOException {
+    // given
+    final var request =
+        "{ \"method\": \"get\", \"url\": \"https://camunda.io/http-endpoint\", \"authentication\": { \"type\": \"noAuth\" } }";
+    final var context = OutboundConnectorContextBuilder.create().variables(request).build();
+
+    when(requestFactory.buildRequest(
+            anyString(), any(GenericUrl.class), nullable(HttpContent.class)))
+        .thenReturn(httpRequest);
+    when(httpResponse.getHeaders())
+        .thenReturn(new HttpHeaders().setContentType(APPLICATION_JSON.getMimeType()));
+    when(httpResponse.getStatusCode()).thenReturn(input);
+    when(httpResponse.parseAsString()).thenReturn("message");
+    doThrow(new HttpResponseException(httpResponse)).when(httpRequest).execute();
+    // when
+    final var result = catchException(() -> functionUnderTest.execute(context));
+    // then HTTP status code is passed on as error code
+    assertThat(result)
+        .isInstanceOf(ConnectorException.class)
+        .extracting("errorCode")
+        .isEqualTo(String.valueOf(input));
   }
 
   private static Stream<String> successCases() throws IOException {


### PR DESCRIPTION
## Description

Passes on any non-2XX HTTP status code as error code in the resulting `ConnectorException`.

## Related issues

related to https://github.com/camunda/team-connectors/issues/195

